### PR TITLE
Fixed Format Code with ID 47 in NumberFormatId-Lookup-Table.md

### DIFF
--- a/NumberFormatId-Lookup-Table.md
+++ b/NumberFormatId-Lookup-Table.md
@@ -227,7 +227,7 @@ range.Style.NumberFormat.NumberFormatId = #;
 
 <td>47</td>
 
-<td>mmss.0</td>
+<td>mm:ss.0</td>
 
 </tr>
 


### PR DESCRIPTION
Fixed Format Code 47 from "mmss.0" to "mm:ss.0" in NumberFormatId-Lookup-Table.md

(reported same typo by feedback form of https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.numberingformat?redirectedfrom=MSDN&view=openxml-2.8.1) (verified with Excel 2019: using the formats "mm:ss.0" "mmss.0" and introspecting the resulting .xlsx file yields:
  <x:xf numFmtId="47" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1" />
  <x:xf numFmtId="164" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1" />
)